### PR TITLE
C2P updates conserved vars after applying species limiter

### DIFF
--- a/include/do_nothing.hpp
+++ b/include/do_nothing.hpp
@@ -26,7 +26,7 @@ class DoNothing : public ErrorPolicyInterface {
     Error MagnetizationResponse(Real& bsq, Real b_u[3]) {return Error::SUCCESS;}
     void DensityLimits(Real& n, Real n_min, Real n_max) {return;}
     void TemperatureLimits(Real& T, Real T_min, Real T_max) {return;}
-    void SpeciesLimits(Real *Y, Real *Y_min, Real *Y_max, int n_species) {return;}
+    bool SpeciesLimits(Real *Y, Real *Y_min, Real *Y_max, int n_species) {return false;}
     void PressureLimits(Real& P, Real P_min, Real P_max) {return;}
     void EnergyLimits(Real& e, Real e_min, Real e_max) {return;}
     bool FailureResponse(Real prim[NPRIM]) {return false;}

--- a/include/eos.hpp
+++ b/include/eos.hpp
@@ -509,8 +509,8 @@ class EOS : public EOSPolicy, public ErrorPolicy {
     }
 
     //! \brief Limit Y to a specified range
-    inline void ApplySpeciesLimits(Real *Y) {
-      SpeciesLimits(Y, min_Y, max_Y, n_species);
+    inline bool ApplySpeciesLimits(Real *Y) {
+      return SpeciesLimits(Y, min_Y, max_Y, n_species);
     }
 
     //! \brief Limit the pressure to a specified range at a given density and composition

--- a/include/primitive_solver.hpp
+++ b/include/primitive_solver.hpp
@@ -355,7 +355,7 @@ inline SolverResult PrimitiveSolver<EOSPolicy, ErrorPolicy>::ConToPrim(Real prim
     Y[s] = cons[IYD + s]/cons[IDN];
   }
   // Apply limits to Y to ensure a physical state
-  peos->ApplySpeciesLimits(Y);
+  bool Y_adjusted = peos->ApplySpeciesLimits(Y);
 
   // Check the conserved variables for consistency and do whatever
   // the EOSPolicy wants us to.
@@ -365,6 +365,13 @@ inline SolverResult PrimitiveSolver<EOSPolicy, ErrorPolicy>::ConToPrim(Real prim
     HandleFailure(prim, cons, b, g3d);
     solver_result.error = Error::CONS_FLOOR;
     return solver_result;
+  }
+  // If a floor is applied or Y is adjusted, we need to propagate the changes back to
+  // DYe.
+  if (floored || Y_adjusted) {
+    for (int s = 0; s < n_species; s++) {
+      cons[IYD + s] = cons[IYD]*Y[s];
+    }
   }
 
   // Calculate some utility quantities.
@@ -502,7 +509,8 @@ inline SolverResult PrimitiveSolver<EOSPolicy, ErrorPolicy>::ConToPrim(Real prim
     solver_result.error = Error::PRIM_FLOOR;
     return solver_result;
   }
-  solver_result.cons_adjusted = solver_result.cons_adjusted || floored || solver_result.cons_floor;
+  solver_result.cons_adjusted = solver_result.cons_adjusted || floored ||
+                                solver_result.cons_floor || Y_adjusted;
 
   prim[IDN] = n;
   prim[IPR] = P;

--- a/include/primitive_solver.hpp
+++ b/include/primitive_solver.hpp
@@ -370,7 +370,7 @@ inline SolverResult PrimitiveSolver<EOSPolicy, ErrorPolicy>::ConToPrim(Real prim
   // DYe.
   if (floored || Y_adjusted) {
     for (int s = 0; s < n_species; s++) {
-      cons[IYD + s] = cons[IYD]*Y[s];
+      cons[IYD + s] = D*Y[s];
     }
   }
 

--- a/include/reset_floor.hpp
+++ b/include/reset_floor.hpp
@@ -38,7 +38,7 @@ class ResetFloor : public ErrorPolicyInterface {
     void TemperatureLimits(Real& T, Real T_min, Real T_max);
 
     /// Policy for resetting species fractions
-    void SpeciesLimits(Real* Y, Real* Y_min, Real* Y_max, int n_species);
+    bool SpeciesLimits(Real* Y, Real* Y_min, Real* Y_max, int n_species);
 
     /// Policy for resetting pressure
     void PressureLimits(Real& P, Real P_min, Real P_max);

--- a/src/reset_floor.cpp
+++ b/src/reset_floor.cpp
@@ -93,10 +93,18 @@ void ResetFloor::EnergyLimits(Real& e, Real e_min, Real e_max) {
 }
 
 /// Apply species limits
-void ResetFloor::SpeciesLimits(Real* Y, Real* Y_min, Real* Y_max, int n_species) {
+bool ResetFloor::SpeciesLimits(Real* Y, Real* Y_min, Real* Y_max, int n_species) {
+  bool adjusted = false;
   for (int i = 0; i < n_species; i++) {
-    Y[i] = std::fmax(Y_min[i], std::fmin(Y_max[i], Y[i]));
+    if (Y[i] < Y_min[i]) {
+      adjusted = true;
+      Y[i] = Y_min[i];
+    } else if (Y[i] > Y_max[i]) {
+      adjusted = true;
+      Y[i] = Y_max[i];
+    }
   }
+  return false;
 }
 
 /// Perform failure response.

--- a/src/reset_floor.cpp
+++ b/src/reset_floor.cpp
@@ -104,7 +104,7 @@ bool ResetFloor::SpeciesLimits(Real* Y, Real* Y_min, Real* Y_max, int n_species)
       Y[i] = Y_max[i];
     }
   }
-  return false;
+  return adjusted;
 }
 
 /// Perform failure response.


### PR DESCRIPTION
During the C2P calculation, there's a limiter applied to $Y_i$. However, changes to $Y_i$ do not propagate back into the conserved variable $DY_i$. The same occurs when the conserved variables are floored (however, a floor on $D$ should result in an automatic floor on $\rho$, so this probably isn't as important). This merge request updates `PrimitiveSolver::ConToPrim` to check if $Y_i$ was changed during the limiting process, and it recalculates $DY_i$ if any $Y_i$ were changed or a conserved floor was applied.