### PR TITLE
n, T, Y floors forced above min_n, min_Y, min_Y.

### DIFF
--- a/include/eos.hpp
+++ b/include/eos.hpp
@@ -386,20 +386,20 @@ class EOS : public EOSPolicy, public ErrorPolicy {
     //  \brief Set the density floor used by the EOS ErrorPolicy.
     //         Also adjusts the pressure and tau floor to be consistent.
     inline void SetDensityFloor(Real floor) {
-      n_atm = (floor >= 0.0) ? floor : 0.0;
+      n_atm = (floor >= min_n) ? floor : min_n;
     }
 
     //! \fn void SetTemperatureFloor(Real floor)
     //  \brief Set the temperature floor (in code units) used by the EOS ErrorPolicy.
     inline void SetTemperatureFloor(Real floor) {
-      T_atm = (floor >= 0.0) ? floor : 0.0;
+      T_atm = (floor >= min_T) ? floor : min_T;
     }
 
     //! \fn void SetSpeciesAtmospher(Real atmo, int i)
     //  \brief Set the atmosphere abundance used by the EOS ErrorPolicy for species i.
     inline void SetSpeciesAtmosphere(Real atmo, int i) {
       assert((i < n_species) && "Not enough species");
-      Y_atm[i] = std::min(1.0, std::max(0.0, atmo));
+      Y_atm[i] = std::min(max_Y[i], std::max(min_Y[i], atmo));
     }
 
     //! \fn void SetThreshold(Real threshold)


### PR DESCRIPTION
This is a simple fix that forces the atmosphere for $n$, $T$, and $Y_i$ to be above their respective minima. Not having this feature can sometimes cause problems with `EOSCompOSE`. Right now the assumption is that an EOS with non-zero minima will be initialized *before* `SetXFloor` or `SetSpeciesAtmosphere` is called. Though good practice, this is not rigorously enforced. Therefore, issues may still occur in this instance.