### PR TITLE
Modified energy limiting in C2P

### DIFF
--- a/include/primitive_solver.hpp
+++ b/include/primitive_solver.hpp
@@ -117,13 +117,13 @@ class PrimitiveSolver {
         // Estimate the energy density.
         Real eoverD = qbar - mu*rbarsq + 1.0;
         Real ehat = D*eoverD;
-        peos->ApplyEnergyLimits(ehat, nhat, Y);
+        //peos->ApplyEnergyLimits(ehat, nhat, Y);
         //eoverD = ehat/D;
 
         // Now we can get an estimate of the temperature, and from that, the pressure and enthalpy.
         Real That = peos->GetTemperatureFromE(nhat, ehat, Y);
         peos->ApplyTemperatureLimits(That);
-        //ehat = peos->GetEnergy(nhat, That, Y);
+        ehat = peos->GetEnergy(nhat, That, Y);
         Real Phat = peos->GetPressure(nhat, That, Y);
         Real hhat = (ehat + Phat)/(nhat*mb);
         //Real hhat = peos->GetEnthalpy(nhat, That, Y);


### PR DESCRIPTION
For `EOSCompOSE`, the energy and pressure limiting is not always correct (see https://github.com/IAS-Astrophysics/athenak/issues/737) thanks to assumptions that may not hold. The energy limiter is applied inside the C2P before the temperature recovery, which in some scenarios can lead to problems where the wrong temperature is recovered, which introduces a kink into the root function that stalls convergence. Removing this limiter and recomputing the energy density after computing the temperature seems to be more reliable.